### PR TITLE
Create FwSign project and initial build system

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,8 +25,8 @@ tab_size = 4
 # C++ code files (note '.h' files not on the list to avoid C headers)
 [*.{c++,cc,cpp,cppm,cxx,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 
-# Doxygen documentation style settings
-cpp_generate_documentation_comments = doxygen_triple_slash
+# Doxygen documentation style settings - javadoc
+cpp_generate_documentation_comments = doxygen_slash_star
 
 # C++ formatting settings
 indent_style = tab

--- a/.github/workflows/build-fwsign.yml
+++ b/.github/workflows/build-fwsign.yml
@@ -1,0 +1,62 @@
+name: Build FwSign
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  # Allows to run this workflow from Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup Ninja
+      run: sudo apt -y install ninja-build
+
+    - name: Checkout pull request HEAD
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Configure CMake
+      working-directory: ${{github.workspace}}
+      run: cmake --preset x64-debug-linux
+
+    - name: Build
+      working-directory: ${{github.workspace}}
+      run: cmake --build --preset x64-debug-linux
+
+    - name: Upload Linux build artifacts
+      uses: actions/upload-artifact@v3.1.0
+      with:
+        name: linux-build-artifacts
+        path: ${{github.workspace}}/build
+
+  build_windows:
+    runs-on: windows-latest
+
+    steps:
+    - name: Enable Developer Command Prompt
+      uses: ilammy/msvc-dev-cmd@v1.10.0
+      with:
+        arch: amd64
+
+    - name: Checkout pull request HEAD
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Configure CMake
+      working-directory: ${{github.workspace}}
+      run: cmake --preset x64-debug-windows
+
+    - name: Build
+      working-directory: ${{github.workspace}}
+      run: cmake --build --preset x64-debug-windows
+
+    - name: Upload Windows build artifacts
+      uses: actions/upload-artifact@v3.1.0
+      with:
+        name: windows-build-artifacts
+        path: ${{github.workspace}}\build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required (VERSION 3.22)
+
+project(FwSign DESCRIPTION "Firmware image creation and signing tool" LANGUAGES CXX)
+
+add_executable(fwsign)
+
+set_property(TARGET fwsign PROPERTY CXX_STANDARD 17)
+
+target_include_directories(fwsign PRIVATE include)
+
+add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,80 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "windows-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "linux-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      // WSL hints
+      "vendor": {
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/workspace/$ms{projectDirName}",
+          "intelliSenseMode": "linux-gcc-x64"
+        }
+      }
+    },
+    {
+      "name": "x64-debug-windows",
+      "displayName": "x64 Debug Windows",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-msvc-x64"
+        }
+      }
+    },
+    {
+      "name": "x64-debug-linux",
+      "displayName": "x64 Debug Linux",
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_SYSTEM_PROCESSOR": "x86_64"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "x64-debug-windows",
+      "displayName": "x64 Debug Windows",
+      "configurePreset": "x64-debug-windows"
+    },
+    {
+      "name": "x64-debug-linux",
+      "displayName": "x64 Debug Linux",
+      "configurePreset": "x64-debug-linux"
+    }
+  ]
+}

--- a/include/fwsign/World.hpp
+++ b/include/fwsign/World.hpp
@@ -1,0 +1,21 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#pragma once
+#include <string_view>
+
+namespace fwsign
+{
+
+class World
+{
+public:
+	std::string_view greet();
+
+private:
+	std::string_view greeting = {"Hello!"};
+};
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+target_sources(fwsign PRIVATE main.cpp
+	World.cpp)

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -1,0 +1,11 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#include <fwsign/World.hpp>
+
+std::string_view fwsign::World::greet()
+{
+	return greeting;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,14 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#include <fwsign/World.hpp>
+#include <iostream>
+
+int main()
+{
+	fwsign::World world;
+	std::cout << world.greet() << std::endl;
+	return 0;
+}


### PR DESCRIPTION
### Created "Hello World" project with dummy headers and sources

- Added CMake files to project structure defining project name, language used and folder structure
- Added src directory for source files and include directory for header definitions
- Set minimal language standards for C++ and CMake
- Added dummy C++ code

### Added CMake configure and build presets for Windows and Linux

- Presets define how the project should be used on both operating systems
- Selected Ninja generator for the project as it is cross-platform
- Added configurations for debug type, release type will be added later

### Added GitHub workflows to build the FwSign project

- New workflow builds FwSign project on both Windows and Linux
- Build is executed on every PR to main branch and may be run on demand from Actions tab
- Build artifacts are uploaded to Github

### Codestyle changes

- Changed style of doxygen documentation in code from "triple slash" that is Microsoft specific to
more commonly used "javadoc" style or "starred".