### PR TITLE
Add unit test framework

### DIFF
--- a/.github/workflows/run-fwsign-unit-tests.yml
+++ b/.github/workflows/run-fwsign-unit-tests.yml
@@ -1,0 +1,51 @@
+name: Run FwSign unit tests
+
+on:
+  workflow_run:
+    workflows: ["Build FwSign"]
+    types:
+      - completed
+
+jobs:
+  run_unit_tests_linux:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+    - name: Checkout pull request HEAD
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Download Linux build artifacts
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: linux-build-artifacts
+        path: ${{github.workspace}}/build
+
+    - name: Relax build artifacts permissions
+      run: sudo chmod 777 -R ${{github.workspace}}/build
+
+    - name: Run Unit Tests
+      working-directory: ${{github.workspace}}
+      run: ctest --preset x64-debug-linux
+
+  run_unit_tests_windows:
+    runs-on: windows-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+    - name: Checkout pull request HEAD
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Download Windows build artifacts
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: windows-build-artifacts
+        path: ${{github.workspace}}\build
+
+    - name: Run Unit Tests
+      working-directory: ${{github.workspace}}
+      run: ctest --preset x64-debug-windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,15 @@ cmake_minimum_required (VERSION 3.22)
 
 project(FwSign DESCRIPTION "Firmware image creation and signing tool" LANGUAGES CXX)
 
-add_executable(fwsign)
+add_executable(FwSign)
+set_target_properties(FwSign PROPERTIES CXX_STANDARD 17)
 
-set_property(TARGET fwsign PROPERTY CXX_STANDARD 17)
-
-target_include_directories(fwsign PRIVATE include)
+add_library(FwSignSources INTERFACE)
+target_include_directories(FwSignSources INTERFACE include)
 
 add_subdirectory(src)
+
+enable_testing()
+add_subdirectory(tests)
+
+target_link_libraries(FwSign PRIVATE FwSignSources)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,5 +76,31 @@
       "displayName": "x64 Debug Linux",
       "configurePreset": "x64-debug-linux"
     }
+  ],
+  "testPresets": [
+    {
+      "name": "x64-debug-windows",
+      "displayName": "x64 Debug Windows",
+      "description": "Executes unit tests for x64 Debug Windows configuration",
+      "configurePreset": "x64-debug-windows",
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false,
+        "scheduleRandom": true,
+        "timeout": 600
+      }
+    },
+    {
+      "name": "x64-debug-linux",
+      "displayName": "x64 Debug Linux",
+      "description": "Executes unit tests for x64 Debug Linux configuration",
+      "configurePreset": "x64-debug-linux",
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false,
+        "scheduleRandom": true,
+        "timeout": 600
+      }
+    }
   ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,5 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-target_sources(fwsign PRIVATE main.cpp
+target_sources(FwSign PRIVATE main.cpp)
+
+# tests implement their own main function - not adding main.cpp here
+target_sources(FwSignSources INTERFACE
 	World.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(FetchContent)
+FetchContent_Declare(
+	googletest
+	GIT_REPOSITORY https://github.com/google/googletest.git
+	GIT_TAG release-1.12.1)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(FwSignUnitTests)
+set_target_properties(FwSignUnitTests PROPERTIES CXX_STANDARD 17)
+target_link_libraries(FwSignUnitTests PUBLIC FwSignSources)
+target_sources(FwSignUnitTests PRIVATE
+	src/HelloTest.cpp)
+
+target_link_libraries(FwSignUnitTests PRIVATE gtest gtest_main gmock)
+
+include(GoogleTest)
+gtest_discover_tests(FwSignUnitTests)

--- a/tests/src/HelloTest.cpp
+++ b/tests/src/HelloTest.cpp
@@ -1,0 +1,23 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#include <gtest/gtest.h>
+#include <fwsign/World.hpp>
+
+namespace fwsign::unit_test
+{
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, HelloWorld)
+{
+	fwsign::World world;
+
+	// Expect two strings not to be equal.
+	EXPECT_STREQ(world.greet().data(), "Hello!");
+}
+
+}
+
+


### PR DESCRIPTION
**Added new framework for unit tests - GTest**

- Added dummy unit test
- Added workflow that executes unit tests after fwsign build workflow completes successfully
- Renamed existing CMake target "fwsign" to "FwSign" to follow PascalCase naming style for targets
- Added CMake interface library FwSignSources to share source files between executable and unit tests