### PR TITLE
Add toml parser library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(FwSignSources INTERFACE)
 target_include_directories(FwSignSources INTERFACE include)
 
 add_subdirectory(src)
+add_subdirectory(external)
 
 enable_testing()
 add_subdirectory(tests)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+include(FetchContent)
+FetchContent_Declare(
+	tomlplusplus
+	GIT_REPOSITORY	https://github.com/marzer/tomlplusplus.git
+	GIT_TAG			v3.2.0
+)
+FetchContent_MakeAvailable(tomlplusplus)
+
+target_compile_definitions(FwSignSources INTERFACE TOML_HEADER_ONLY)
+target_include_directories(FwSignSources INTERFACE ${tomlplusplus_SOURCE_DIR}/include)

--- a/include/fwsign/World.hpp
+++ b/include/fwsign/World.hpp
@@ -13,6 +13,7 @@ class World
 {
 public:
 	std::string_view greet();
+	int parse(const std::string_view toml);
 
 private:
 	std::string_view greeting = {"Hello!"};

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -4,8 +4,45 @@
 */
 
 #include <fwsign/World.hpp>
+#include <toml++/toml.h>
+#include <iostream>
+#include <sstream>
 
-std::string_view fwsign::World::greet()
+namespace fwsign
+{
+
+std::string_view World::greet()
 {
 	return greeting;
 }
+
+int World::parse(const std::string_view toml)
+{
+	try
+	{
+		// parse directly from a string view:
+		{
+			toml::table tbl = toml::parse(toml);
+			std::cout << tbl << "\n";
+		}
+
+		// parse from a string stream:
+		{
+			std::stringstream ss{std::string{toml}};
+			toml::table tbl = toml::parse(ss);
+			std::cout << tbl << "\n";
+		}
+	}
+	catch(const toml::parse_error& err)
+	{
+		std::cerr << "Parsing failed:\n" << err << "\n";
+		return 1;
+	}
+
+	return 0;
+}
+
+}
+
+
+

--- a/tests/src/HelloTest.cpp
+++ b/tests/src/HelloTest.cpp
@@ -18,6 +18,34 @@ TEST(HelloTest, HelloWorld)
 	EXPECT_STREQ(world.greet().data(), "Hello!");
 }
 
+TEST(HelloTest, TomlParser)
+{
+	static constexpr std::string_view some_toml = R"(
+		[library]
+		name = "toml++"
+		authors = ["Mark Gillard <mark.gillard@outlook.com.au>"]
+		cpp = 17
+	)";
+
+	fwsign::World world;
+
+	EXPECT_EQ(world.parse(some_toml), 0);
+}
+
+TEST(HelloTest, TomlParserBadFormat)
+{
+	static constexpr std::string_view some_toml = R"(
+		[library]]
+		name = "toml++"
+		authors = ["Mark Gillard <mark.gillard@outlook.com.au>"]
+		cpp = 17
+	)";
+
+	fwsign::World world;
+
+	EXPECT_EQ(world.parse(some_toml), 1);
+}
+
 }
 
 


### PR DESCRIPTION
This PR adds toml files parser library - [tomlplusplus](https://marzer.github.io/tomlplusplus/#mainpage-example-parsing-strings).
The new library is a waypoint for implementing #7 .

- New library is header only and is downloaded during CMake configure time
- Added dummy `World::parse` function to test new library functionality (parsing from string)
- Added two simple unit tests to check if `World::parse` works

Signed-off-by: Andrey Borisovich <business@borisovich.com>