### PR TITLE
Mark header files as sources in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ add_executable(FwSign)
 set_target_properties(FwSign PROPERTIES CXX_STANDARD 17)
 
 add_library(FwSignSources INTERFACE)
-target_include_directories(FwSignSources INTERFACE include)
 
+add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(external)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+target_include_directories(FwSignSources INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# In CMake header files are also sources.
+# CMake generates list of dependencies for every source file compiled
+# and if header file changes then all compilation units including it will
+# be rebuild.
+target_sources(FwSignSources INTERFACE
+	fwsign/World.hpp)


### PR DESCRIPTION
Header files are sources in CMake.
This approach allows to reuse CMake cache that works as it should. Every source file including header that was modified is rebuild by CMake that recognizes those dependencies.

Signed-off-by: Andrey Borisovich <business@borisovich.com>