### PR TITLE
Created Microsoft C++ Code Analysis workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,0 +1,58 @@
+name: Microsoft C++ Code Analysis
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  build_dir: ${{github.workspace}}\build\x64-debug-windows
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    permissions:
+      contents: read            # for actions/checkout to fetch code
+      security-events: write    # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read             # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Analyze
+    runs-on: windows-latest
+
+    steps:
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1.10.0
+        with:
+          arch: amd64
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure CMake
+        run: cmake --preset x64-debug-windows
+
+      - name: Initialize MSVC Code Analysis
+        uses: microsoft/msvc-code-analysis-action@v0.1.1
+        # Provide a unique ID to access the sarif output path
+        id: run-analysis
+        with:
+          cmakeBuildDirectory: ${{ env.build_dir }}
+          # Ruleset file that will determine what checks will be run
+          ruleset: NativeRecommendedRules.ruleset
+          ignoredPaths: ${{ github.workspace }}\external;${{ github.workspace }}\tests;${{ env.build_dir }}\_deps
+
+      # Upload SARIF file to GitHub Code Scanning Alerts
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.run-analysis.outputs.sarif }}
+
+      # Upload SARIF file as an Artifact to download and view
+      - name: Upload SARIF as an Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sarif-file
+          path: ${{ steps.run-analysis.outputs.sarif }}


### PR DESCRIPTION
Code analysis is executed on every Pull Request to the main branch, daily at midnight UTC time, and may be triggered on demand from the Actions tab. Scan results are saved as SARIF files in build artifacts.
Runs on Windows with MSVC.
Unfortunately, other tools that I tested (CppCheck, CodeQL) proved unreliable, and could not find an analysis tool that would also work with GCC on linux.

Signed-off-by: Andrey Borisovich <business@borisovich.com>