### PR TITLE
Added TomlReader class with unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(FwSign)
 set_target_properties(FwSign PROPERTIES CXX_STANDARD 17)
 
 add_library(FwSignSources INTERFACE)
+target_compile_options(FwSignSources INTERFACE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
 add_subdirectory(include)
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,7 +47,8 @@
         "strategy": "external"
       },
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -61,7 +62,8 @@
       "inherits": "linux-base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_SYSTEM_PROCESSOR": "x86_64"
+        "CMAKE_SYSTEM_PROCESSOR": "x86_64",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     }
   ],

--- a/config/mtl.toml
+++ b/config/mtl.toml
@@ -1,0 +1,395 @@
+version = [3, 0]
+
+[adsp]
+name = "mtl"
+image_size = "0x2C0000" # (22) bank * 128KB
+
+[[adsp.mem_zone]]
+type = "ROM"
+base = "0x1FF80000"
+size = "0x400"
+[[adsp.mem_zone]]
+type = "IMR"
+base = "0xA104A000"
+size = "0x2000"
+[[adsp.mem_zone]]
+type = "SRAM"
+base = "0xa00f0000"
+size = "0x100000"
+
+[cse]
+partition_name = "ADSP"
+[[cse.entry]]
+name = "ADSP.man"
+offset = "0x5c"
+length = "0x464"
+[[cse.entry]]
+name = "ADSP.met"
+offset = "0x4c0"
+length = "0x70"
+[[cse.entry]]
+name = "ADSP"
+offset = "0x540"
+length = "0x0"  # calculated by rimage
+
+[css]
+
+[signed_pkg]
+name = "ADSP"
+partition_usage = "0x23"
+[[signed_pkg.module]]
+name = "ADSP.met"
+
+[adsp_file]
+[[adsp_file.comp]]
+base_offset = "0x2000"
+
+[fw_desc.header]
+name = "ADSPFW"
+load_offset = "0x40000"
+
+[module]
+count = 15
+	[[module.entry]]
+	name = "BRNGUP"
+	uuid = "2B79E4F3-4675-F649-89DF-3BC194A91AEB"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "BASEFW"
+	uuid = "0E398C32-5ADE-BA4B-93B1-C50432280EE4"
+	affinity_mask = "3"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0"
+	auto_start = "0"
+
+	[[module.entry]]
+	name = "MIXIN"
+	uuid = "39656EB2-3B71-4049-8D3F-F92CD5C43C09"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "1"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0,   0,   0xfeef, 0xc,  0x8,   0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+		   1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 296, 644000, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 296, 669900, 48, 64, 0, 0, 0,
+				2, 0, 0, 0, 296, 934000, 96, 128, 0, 0, 0,
+				3, 0, 0, 0, 296, 1137000, 96, 128, 0, 0, 0,
+				4, 0, 0, 0, 296, 1482000, 48, 64, 0, 0, 0,
+				5, 0, 0, 0, 296, 1746000, 96, 128, 0, 0, 0,
+				6, 0, 0, 0, 296, 2274000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 296, 2700000, 48, 64, 0, 0, 0,
+				8, 0, 0, 0, 296, 2964000, 96, 128, 0, 0, 0,
+				9, 0, 0, 0, 296, 3492000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "MIXOUT"
+	uuid = "3C56505A-24D7-418F-BDDC-C1F5A3AC2AE0"
+	affinity_mask = "0x1"
+	instance_count = "30"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "2"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 520, 649600, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 520, 966300, 96, 128, 0, 0, 0,
+				2, 0, 0, 0, 520, 2101000, 48, 64, 0, 0, 0,
+				3, 0, 0, 0, 520, 2500800, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 520, 2616700, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 520, 2964500, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 520, 4202000, 96, 128, 0, 0, 0,
+				7, 0, 0, 0, 520, 3730000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "COPIER"
+	uuid = "9BA00C83-CA12-4A83-943C-1FA2E82F9DDA"
+	affinity_mask = "0x1"
+	instance_count = "32"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "3"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [ 0, 0, 0, 0, 280, 640100, 45, 60, 0, 0, 0,
+				1, 0, 0, 0, 280, 1106300, 192, 192, 0, 0, 0,
+				2, 0, 0, 0, 280, 1573000, 45, 45, 0, 0, 0,
+				3, 0, 0, 0, 280, 2040600, 192, 256, 0, 0, 0,
+				4, 0, 0, 0, 280, 2507500, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 280, 2999000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 280, 3501000, 45, 60, 0, 0, 0,
+				7, 0, 0, 0, 280, 3927000, 192, 256, 0, 0, 0,
+				8, 0, 0, 0, 280, 4424000, 192, 256, 0, 0, 0,
+				9, 0, 0, 0, 280, 4941000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PEAKVOL"
+	uuid = "8A171323-94A3-4E1D-AFE9-FE5DBAA4C393"
+	affinity_mask = "0x1"
+	instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "4"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 480, 3321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 480, 3786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 480, 4333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 480, 4910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 480, 5441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 480, 6265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "GAIN"
+	uuid = "61BCA9A8-18D0-4A18-8E7B-2639219804B7"
+	affinity_mask = "0x1"
+	instance_count = "40"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "5"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xf, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 416, 914000, 48, 64, 0, 0, 0,
+				1, 0, 0, 0, 416, 1321600, 192, 256, 0, 0, 0,
+				2, 0, 0, 0, 416, 1786000, 192, 256, 0, 0, 0,
+				3, 0, 0, 0, 416, 2333000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 416, 2910000, 192, 256, 0, 0, 0,
+				5, 0, 0, 0, 416, 3441000, 192, 256, 0, 0, 0,
+				6, 0, 0, 0, 416, 4265000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "ASRC"
+	uuid = "66B4402D-B468-42F2-81A7-B37121863DD4"
+	affinity_mask = "0x3"
+	instance_count = "2"
+	domain_types = "0"
+
+	load_type = "0"
+	module_type = "6"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	pin = [0, 0, 0xfeef, 0xc, 0x8, 0x45ff,
+			1, 0, 0xfeef, 0xc, 0x8, 0x45ff]
+
+	mod_cfg = [0, 0, 0, 0, 20480, 4065600, 24, 22, 0, 0, 0,
+				1, 0, 0, 0, 20480, 5616000, 8, 25, 0, 0, 0,
+				2, 0, 0, 0, 20480, 7319200, 24, 27, 0, 0, 0,
+				3, 0, 0, 0, 20480, 9155300, 8, 27, 0, 0, 0,
+				4, 0, 0, 0, 20480, 10972600, 48, 54, 0, 0, 0,
+				5, 0, 0, 0, 20480, 12661000, 16, 36, 0, 0, 0,
+				6, 0, 0, 0, 20480, 14448500, 48, 96, 0, 0, 0,
+				7, 0, 0, 0, 20480, 16145000, 19, 68, 0, 0, 0,
+				8, 0, 0, 0, 20480, 17861300, 45, 102, 0, 0, 0,
+				9, 0, 0, 0, 20480, 21425900, 8, 36, 0, 0, 0,
+				10, 0, 0, 0, 20480, 22771000, 32, 102, 0, 0, 0,
+				11, 0, 0, 0, 20480, 23439000, 48, 27, 0, 0, 0,
+				12, 0, 0, 0, 20480, 33394000, 48, 51, 0, 0, 0,
+				13, 0, 0, 0, 20480, 36140000, 16, 96, 0, 0, 0,
+				14, 0, 0, 0, 20480, 38003000, 16, 68, 0, 0, 0,
+				15, 0, 0, 0, 20480, 39787000, 45, 51, 0, 0, 0]
+
+	[[module.entry]]
+	name = "SRC"
+	uuid = "E61BB28D-149A-4C1F-B709-46823EF5F5AE"
+	affinity_mask = "0x1"
+	#instance_count = "10"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "7"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xf6c9, 0xc, 0x8, 0x05ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 12832, 1365500, 0, 0, 0, 1365, 0,
+				1, 0, 0, 0, 12832, 2302300, 0, 0, 0, 2302, 0,
+				2, 0, 0, 0, 12832, 3218200, 0, 0, 0, 3218, 0,
+				3, 0, 0, 0, 12832, 4169700, 0, 0, 0, 4169, 0,
+				4, 0, 0, 0, 12832, 5095100, 0, 0, 0, 5095, 0,
+				5, 0, 0, 0, 12832, 6014800, 0, 0, 0, 6014, 0,
+				6, 0, 0, 0, 12832, 6963500, 0, 0, 0, 6963, 0,
+				7, 0, 0, 0, 12832, 7791000, 0, 0, 0, 7791, 0,
+				8, 0, 0, 0, 12832, 8843000, 0, 0, 0, 8843, 0,
+				9, 0, 0, 0, 12832, 9755100, 0, 0, 0, 9755, 0,
+				10, 0, 0, 0, 12832, 10726500, 0, 0, 0, 10726, 0,
+				11, 0, 0, 0, 12832, 11624100, 0, 0, 0, 11624, 0,
+				12, 0, 0, 0, 12832, 12518700, 0, 0, 0, 12518, 0,
+				13, 0, 0, 0, 12832, 13555000, 0, 0, 0, 13555, 0,
+				14, 0, 0, 0, 12832, 14144500, 0, 0, 0, 14144, 0,
+				15, 0, 0, 0, 12832, 15809800, 0, 0, 0, 15809, 0,
+				16, 0, 0, 0, 12832, 16749000, 0, 0, 0, 16749, 0,
+				17, 0, 0, 0, 12832, 18433500, 0, 0, 0, 18433, 0,
+				18, 0, 0, 0, 12832, 19425900, 0, 0, 0, 19425, 0,
+				19, 0, 0, 0, 12832, 20396900, 0, 0, 0, 20396, 0,
+				20, 0, 0, 0, 12832, 20881000, 0, 0, 0, 20881, 0,
+				21, 0, 0, 0, 12832, 23431000, 0, 0, 0, 23431, 0,
+				22, 0, 0, 0, 12832, 30471000, 0, 0, 0, 30471, 0]
+
+	[[module.entry]]
+	name = "MICSEL"
+	uuid = "32FE92C1-1E17-4FC2-9758-C7F3542E980A"
+	affinity_mask = "0x1"
+	instance_count = "8"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "8"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xe, 0xa, 0x45ff, 1, 0, 0xfeef, 0xe, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 960, 488500, 16, 16, 0, 0, 0,
+			1, 0, 0, 0, 960, 964500, 16, 16, 0, 0, 0,
+			2, 0, 0, 0, 960, 2003000, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "UPDWMIX"
+	uuid = "42F8060C-832F-4DBF-B247-51E961997B34"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "9"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xffff, 0xc, 0x8, 0x05ff,
+			1, 0, 0xffff, 0xc, 0x8, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 216, 706000, 12, 16, 0, 0, 0,
+				1, 0, 0, 0, 216, 1271000, 8, 8, 0, 0, 0,
+				2, 0, 0, 0, 216, 1839000, 89, 118, 0, 0, 0,
+				3, 0, 0, 0, 216, 2435000, 48, 64, 0, 0, 0,
+				4, 0, 0, 0, 216, 3343000, 192, 192, 0, 0, 0,
+				5, 0, 0, 0, 216, 3961000, 177, 177, 0, 0, 0,
+				6, 0, 0, 0, 216, 4238000, 192, 256, 0, 0, 0,
+				7, 0, 0, 0, 216, 6691000, 192, 256, 0, 0, 0]
+
+	[[module.entry]]
+	name = "PROBE"
+	uuid = "7CAD0808-AB10-CD23-EF45-12AB34CD56EF"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "0"
+	module_type = "0xA"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 4096, 100000, 48, 48, 0, 1000, 0]
+
+ 	[[module.entry]]
+	name = "MUX"
+	uuid = "64ce6e35-857a-4878-ace8-e2a2f42e3069"
+	affinity_mask = "0x1"
+	instance_count = "15"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0xB"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			0, 0, 0xfeef, 0xf, 0xa, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 280, 460700, 16, 16, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KDTEST"
+	uuid = "EBA8D51F-7827-47B5-82EE-DE6E7743AF67"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0xC"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 480, 1114000, 64, 64, 0, 0, 0]
+
+	[[module.entry]]
+	name = "KPB"
+	uuid = "D8218443-5FF3-4A4C-B388-6CFE07B9562E"
+	affinity_mask = "0x1"
+	instance_count = "1"
+	domain_types = "0"
+	load_type = "1"
+	module_type = "0xD"
+	auto_start = "0"
+	sched_caps = [1, 0x00008000]
+
+	# pin = [dir, type, sample rate, size, container, channel-cfg]
+	pin = [0, 0, 0xfeef, 0xf, 0xf, 0x45ff,
+			1, 0, 0xfeef, 0xf, 0xa, 0x45ff]
+
+	# mod_cfg [PAR_0 PAR_1 PAR_2 PAR_3 IS_BYTES CPS IBS OBS MOD_FLAGS CPC OBLS]
+	mod_cfg = [0, 0, 0, 0, 14400, 1114000, 16, 16, 0, 0, 0]

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -11,4 +11,5 @@ target_include_directories(FwSignSources INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 # and if header file changes then all compilation units including it will
 # be rebuild.
 target_sources(FwSignSources INTERFACE
-	fwsign/World.hpp)
+	fwsign/World.hpp
+	fwsign/TomlReader.hpp)

--- a/include/fwsign/TomlReader.hpp
+++ b/include/fwsign/TomlReader.hpp
@@ -1,0 +1,25 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#pragma once
+#include <toml++/toml.h>
+#include <filesystem>
+#include <optional>
+
+namespace fwsign
+{
+
+class TomlReader
+{
+public:
+	std::optional<toml::table> tomlFileRead(std::filesystem::path filePath);
+
+private:
+	bool resolveFilePath(std::filesystem::path& filePath);
+
+	std::filesystem::path defaultConfigsDir = { "./config" };
+};
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(FwSign PRIVATE main.cpp)
 
 # tests implement their own main function - not adding main.cpp here
 target_sources(FwSignSources INTERFACE
-	World.cpp)
+	World.cpp
+	TomlReader.cpp)

--- a/src/TomlReader.cpp
+++ b/src/TomlReader.cpp
@@ -1,0 +1,76 @@
+
+#include <fwsign/TomlReader.hpp>
+#include <iostream>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace fwsign
+{
+
+std::optional<toml::table> TomlReader::tomlFileRead(fs::path filePath)
+{
+	if(!resolveFilePath(filePath))
+		return std::nullopt;
+
+	toml::table result;
+	try
+	{
+		result = toml::parse_file(filePath.c_str());
+	}
+	catch(const toml::parse_error& e)
+	{
+		std::cerr << e.what() << std::endl;
+		return std::nullopt;
+	}
+
+	return result;
+}
+
+bool TomlReader::resolveFilePath(fs::path& filePath)
+{
+	// if only filename passed use defaultConfigDir
+	if(filePath.has_filename() &&
+		filePath.has_extension() &&
+		!filePath.has_parent_path())
+	{
+		filePath = defaultConfigsDir / filePath;
+		filePath = filePath.lexically_normal();
+	}
+
+	if(!fs::exists(filePath))
+	{
+		std::cerr << "File or directory not found: " << filePath << std::endl;
+		return false;
+	}
+
+	if(fs::is_symlink(filePath))
+	{
+		filePath = fs::read_symlink(filePath);
+	}
+
+	if(!fs::is_regular_file(filePath))
+	{
+		std::cerr << "Provided path: " << filePath << " is not a regular file!" << std::endl;
+		return false;
+	}
+
+	if(fs::is_empty(filePath))
+	{
+		std::cerr << "File is empty: " << filePath << std::endl;
+		return false;
+	}
+
+	if(!filePath.has_extension() || filePath.extension() != ".toml")
+	{
+		std::cerr << "File does not have .toml extension: " << filePath << std::endl;
+		return false;
+	}
+
+	filePath = fs::absolute(filePath);
+
+	return true;
+}
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,9 @@ FetchContent_MakeAvailable(googletest)
 add_executable(FwSignUnitTests)
 set_target_properties(FwSignUnitTests PROPERTIES CXX_STANDARD 17)
 target_link_libraries(FwSignUnitTests PUBLIC FwSignSources)
-target_sources(FwSignUnitTests PRIVATE
-	src/HelloTest.cpp)
+
+add_subdirectory(include)
+add_subdirectory(src)
 
 target_link_libraries(FwSignUnitTests PRIVATE gtest gtest_main gmock)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,4 +27,4 @@ include(GoogleTest)
 gtest_discover_tests(FwSignUnitTests)
 
 # Copy test resource files
-configure_file(${PROJECT_SOURCE_DIR}/config/mtl.toml ${CMAKE_CURRENT_BINARY_DIR}/mtl.toml COPYONLY)
+configure_file(${PROJECT_SOURCE_DIR}/config/mtl.toml ${CMAKE_CURRENT_BINARY_DIR}/config/mtl.toml COPYONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,3 +24,6 @@ target_link_libraries(FwSignUnitTests PRIVATE gtest gtest_main gmock)
 
 include(GoogleTest)
 gtest_discover_tests(FwSignUnitTests)
+
+# Copy test resource files
+configure_file(${PROJECT_SOURCE_DIR}/config/mtl.toml ${CMAKE_CURRENT_BINARY_DIR}/mtl.toml COPYONLY)

--- a/test/include/CMakeLists.txt
+++ b/test/include/CMakeLists.txt
@@ -7,4 +7,5 @@
 target_include_directories(FwSignUnitTests PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 target_include_directories(FwSignUnitTests PRIVATE
-	"fwsign/test_utils/Filehandler.hpp")
+	"fwsign/test_utils/Filehandler.hpp"
+	"fwsign/test_utils/TomlReaderTestFixture.hpp")

--- a/test/include/CMakeLists.txt
+++ b/test/include/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+target_include_directories(FwSignUnitTests PRIVATE ${CMAKE_CURRENT_LIST_DIR})

--- a/test/include/CMakeLists.txt
+++ b/test/include/CMakeLists.txt
@@ -5,3 +5,6 @@
 #
 
 target_include_directories(FwSignUnitTests PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+target_include_directories(FwSignUnitTests PRIVATE
+	"fwsign/test_utils/Filehandler.hpp")

--- a/test/include/fwsign/test_utils/FileHandler.hpp
+++ b/test/include/fwsign/test_utils/FileHandler.hpp
@@ -1,0 +1,29 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <string_view>
+#include <string>
+
+namespace fwsign::test::utils
+{
+
+class FileHandler final
+{
+public:
+	FileHandler() = default;
+	FileHandler(std::string_view fileContent) : fileContent(fileContent) {};
+	std::string_view fileRead(const std::filesystem::path& filePath);
+	void fileWrite(const std::filesystem::path& filePath) const;
+	void fileWrite(const std::filesystem::path& filePath, std::string_view fileContent);
+	void printState(const std::ios& stream);
+
+private:
+	std::string fileContent;
+};
+
+}

--- a/test/include/fwsign/unit_test/TomlReaderTestFixture.hpp
+++ b/test/include/fwsign/unit_test/TomlReaderTestFixture.hpp
@@ -1,0 +1,120 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#pragma once
+#include <filesystem>
+#include <vector>
+#include <string>
+
+namespace fwsign::test::unit_test
+{
+
+class TomlReaderTestFixture final
+{
+public:
+	const std::filesystem::path exampleTomlFilename = {"mtl.toml"};
+	const std::filesystem::path fwsignConfigDir = {"config"};
+	const std::filesystem::path badTomlFilename = {"bad_mtl.toml"};
+	const std::filesystem::path notAtomlFile = {"mtl.xml"};
+	const std::string badTomlContent =
+		"[[adsp.mem_zone]]\n"
+		"type = \"ROM\"\n"
+		"base = \"0x1FF80000\"\n"
+		"size = \"0x400\"\n"
+		"[[adsp.mem_zone]]\n"
+		"type = \"IMR\"\n"
+		"base = \"0xA104A000\"\n"
+		"size = \"0x2000\"\n"
+		"[[adsp.mem_zone]]]\n"
+		"type = \"SRAM\"\n"
+		"base = \"0xa00f0000\"\n"
+		"size = \"0x100000\"\n";
+
+	struct TomlTypesData
+	{
+		const std::filesystem::path matchingFormatTextFilename = {"formatted_data.toml"};
+
+		/**
+		 * @brief This text contains specially adjusted whitespaces to match
+		 * toml content after parsing by tomlplusplus library.
+		*/
+		const std::vector<std::string> matchingFormatText =
+		{
+			"astring = 'some text'",
+			"multilineString = '''\"starts\n"
+			"here and goes\n"
+			"here...\"'''",
+			"literalString = 'some\\path\\with\\backslash'",
+			"multilineLiteralString = '''something here\n"
+			"and\\backslash\\path\n"
+			"and termination'''",
+			"positiveInt1 = 9993939",
+			"positiveInt2 = 999993333",
+			"negativeInt = -82134526",
+			"positiveFloat1 = 3.5",
+			"positiveFloat2 = 6.25",
+			"negativeFloat = -995.921875",
+			"bolean1 = true",
+			"bolean2 = false",
+			"offsetdatetime1 = 2020-02-20T06:10:20Z",
+			"offsetdatetime2 = 2030-02-26T06:11:20Z",
+			"localdatetime = 2020-02-20T06:10:20",
+			"date-key = 2020-02-20",
+			"time-key = 06:10:20",
+			"numbers = [ 1, 2, 3, 4 ]",
+			"strings = [ 'ONE', 'TWO', 'THREE' ]",
+			"floats = [ 3.5, 3.75, 999999.75 ]",
+			"mixed = [ 3, 999999.75, 'QWEQWE', false ]",
+			"nested-array = [ [ 2, 3 ], [ 5, 6 ] ]",
+			"[[somename]]\n"
+			"val1 = 'VAL1'\n"
+			"val2 = 'VAL2'"
+		};
+
+		const std::filesystem::path mixedFormatTexttFilename = {"mixed_format_data.toml"};
+
+		/**
+		 * @brief This text contains similar content to
+		 * @var matchingFormatText however with mixed whitespaces,
+		 * formatting styles and comments.
+		*/
+		const std::vector<std::string> mixedFormatText =
+		{
+			"astring=\"some text\"",
+			"multilineString = \"\"\"\"starts\n"
+			"here and goes\n"
+			"here...\"\"\"\"",
+			"literalString = 'some\\path\\with\\backslash'",
+			"multilineLiteralString = '''something here\n"
+			"and\\backslash\\path\n"
+			"and termination'''",
+			"positiveInt1 = +9993939",
+			"positiveInt2 =+999993333",
+			"negativeInt = -82134526",
+			"positiveFloat1 = 3.5",
+			"positiveFloat2=+6.25 # some comments here",
+			"negativeFloat =-995.921875",
+			"bolean1=true",
+			"bolean2 = false",
+			"offsetdatetime1= 2020-02-20T06:10:20Z",
+			"offsetdatetime2=2030-02-26 06:11:20Z",
+			"localdatetime =2020-02-20 06:10:20",
+			"date-key =2020-02-20",
+			"time-key= 06:10:20",
+			"numbers= [1,2,3,4]",
+			"strings =[\"ONE\",\"TWO\",\"THREE\"]",
+			"floats=[+3.5,+3.75,999999.75 ]",
+			"mixed= [ 3, 999999.75, 'QWEQWE', false ]",
+			"nested-array = [ [2,3], [5,6]]",
+			"[[  somename  ]]\n"
+			"val1='VAL1'\n"
+			"val2='VAL2'"
+		};
+	};
+
+	TomlTypesData tomlTypesData;
+};
+
+}

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 Andrey Borisovich Quality Technologies
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+target_sources(FwSignUnitTests PRIVATE
+	"unit_test/HelloTest.cpp")

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 target_sources(FwSignUnitTests PRIVATE
-	"unit_test/HelloTest.cpp")
+	"unit_test/HelloTest.cpp"
+	"test_utils/FileHandler.cpp")

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -6,4 +6,5 @@
 
 target_sources(FwSignUnitTests PRIVATE
 	"unit_test/HelloTest.cpp"
+	"unit_test/TomlReaderTest.cpp"
 	"test_utils/FileHandler.cpp")

--- a/test/src/test_utils/FileHandler.cpp
+++ b/test/src/test_utils/FileHandler.cpp
@@ -1,0 +1,68 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#include <fwsign/test_utils/FileHandler.hpp>
+#include <iostream>
+#include <fstream>
+
+namespace fwsign::test::utils
+{
+
+namespace fs = std::filesystem;
+
+std::string_view FileHandler::fileRead(const std::filesystem::path& filePath)
+{
+	fileContent = "";
+	if(!fs::exists(filePath))
+		throw fs::filesystem_error("No such file or directory", filePath, std::error_code());
+	if(!fs::is_regular_file(filePath))
+		throw fs::filesystem_error("Path target is not a regular file", filePath, std::error_code());
+	std::ifstream file;
+	file.open(filePath);
+	if(file.is_open())
+	{
+		while(file)
+		{
+			char c = file.get();
+			if(c != EOF)
+				fileContent += c;
+		}
+		if(fileContent.empty())
+			printState(file);
+		file.close();
+	}
+
+	return std::string_view(fileContent);
+}
+
+void FileHandler::fileWrite(const std::filesystem::path& filePath, std::string_view fileContent)
+{
+	this->fileContent = fileContent;
+	fileWrite(filePath);
+}
+
+void FileHandler::fileWrite(const std::filesystem::path& filePath) const
+{
+	if(fs::exists(filePath) && !fs::is_regular_file(filePath))
+		throw fs::filesystem_error("Path exists but is not a file", filePath, std::error_code());
+
+	if(filePath.has_parent_path())
+		fs::create_directories(filePath.parent_path());
+
+	std::ofstream file;
+	file.open(filePath, std::ios::out | std::ios::trunc);
+	if(file.is_open())
+		file << fileContent;
+	file.close();
+}
+
+void FileHandler::printState(const std::ios& stream)
+{
+	std::cout << " good()=" << stream.good();
+	std::cout << " eof()=" << stream.eof();
+	std::cout << " fail()=" << stream.fail();
+	std::cout << " bad()=" << stream.bad();
+}
+}

--- a/test/src/unit_test/HelloTest.cpp
+++ b/test/src/unit_test/HelloTest.cpp
@@ -6,7 +6,7 @@
 #include <gtest/gtest.h>
 #include <fwsign/World.hpp>
 
-namespace fwsign::unit_test
+namespace fwsign::test::unit_test
 {
 
 // Demonstrate some basic assertions.

--- a/test/src/unit_test/TomlReaderTest.cpp
+++ b/test/src/unit_test/TomlReaderTest.cpp
@@ -1,0 +1,136 @@
+/**
+ * @copyright Andrey Borisovich Quality Technologies
+ * SPDX - License - Identifier: Apache - 2.0
+*/
+
+#include <fwsign/unit_test/TomlReaderTestFixture.hpp>
+#include <fwsign/test_utils/FileHandler.hpp>
+#include <fwsign/TomlReader.hpp>
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <optional>
+#include <sstream>
+#include <iostream>
+
+namespace fwsign::test::unit_test
+{
+
+namespace fs = std::filesystem;
+
+class TomlReaderTest : public ::testing::TestWithParam<fs::path>, public ::testing::EmptyTestEventListener
+{
+public:
+	virtual void SetUp()
+	{
+		// write config/formatted_data.toml file
+		const fs::path tomlFileInConfigDir(fixture.fwsignConfigDir /
+			fixture.tomlTypesData.matchingFormatTextFilename);
+		std::string textToWrite;
+		for(auto& entry : fixture.tomlTypesData.matchingFormatText)
+		{
+			textToWrite += entry + "\n";
+		}
+		fileHandler.fileWrite(tomlFileInConfigDir, textToWrite);
+		ASSERT_FALSE(fs::is_empty(tomlFileInConfigDir));
+
+		// write config/bad_mtl.toml
+		fileHandler.fileWrite(fixture.fwsignConfigDir / fixture.badTomlFilename,
+			fixture.badTomlContent);
+		ASSERT_FALSE(fs::is_empty(fixture.fwsignConfigDir / fixture.badTomlFilename));
+
+		// copy mtl.toml as mtl.xml
+		const fs::path xmlFile = fixture.fwsignConfigDir / fixture.notAtomlFile;
+		fs::copy_file(fixture.fwsignConfigDir / fixture.exampleTomlFilename, xmlFile,
+			fs::copy_options::overwrite_existing);
+		ASSERT_FALSE(fs::is_empty(xmlFile));
+
+		// write config/mixed_format_data.toml
+		textToWrite = "";
+		const fs::path mixedFormatToml = fixture.fwsignConfigDir / fixture.tomlTypesData.mixedFormatTexttFilename;
+		for(auto& entry : fixture.tomlTypesData.mixedFormatText)
+		{
+			textToWrite += entry + "\n";
+		}
+		fileHandler.fileWrite(mixedFormatToml, textToWrite);
+		ASSERT_FALSE(fs::is_empty(mixedFormatToml));
+	}
+
+	virtual void OnTestEnd(const ::testing::TestInfo& test_info)
+	{
+		if(test_info.result()->Failed())
+		{
+			std::cout << test_info.test_case_name() << "   failed   " << test_info.name() << std::endl;
+		}
+	}
+
+	TomlReaderTestFixture fixture;
+	fwsign::test::utils::FileHandler fileHandler;
+};
+
+INSTANTIATE_TEST_CASE_P(TomlReaderParamTest, TomlReaderTest, ::testing::Values(
+	fs::path("config/formatted_data.toml"),		// relative path
+	fs::path("formatted_data.toml"),				// only filename - search in config directory
+	fs::path("mixed_format_data.toml"),				// same data but with different whitespaces and comments
+	fs::path("config"),								// directory name - expect error
+	fs::path("mtl.xml"),							// wrong file extension - expect error
+	fs::path("in/nonexistant.toml")				// file does not exist - expect error
+));
+
+/**
+ * @brief This recursive test validates how TomlFileReader behaves
+ * when different paths are passed to tomlFileRead function and
+ * different formats of toml is provided.
+ * @param  Test class name used by GTest.
+ * @param  Test name used by GTest.
+*/
+TEST_P(TomlReaderTest, readingTomlFileFormattedData)
+{
+	fs::path pathTested = GetParam();
+	fwsign::TomlReader tomlReader;
+	std::optional<toml::table> result = tomlReader.tomlFileRead(pathTested);
+
+	if(!fs::exists(pathTested) && !fs::exists(fixture.fwsignConfigDir / pathTested))
+	{
+		ASSERT_FALSE(result.has_value());
+		return;
+	}
+
+	if(!fs::is_regular_file(pathTested) && !fs::is_regular_file(fixture.fwsignConfigDir / pathTested))
+	{
+		ASSERT_FALSE(result.has_value());
+		return;
+	}
+
+	if(pathTested.extension() != ".toml")
+	{
+		ASSERT_FALSE(result.has_value());
+		return;
+	}
+
+	std::ostringstream temp;
+	temp << result.value();
+	std::string stringResult = temp.str();
+
+	// toml content after parsing is unordered - check for substrings
+	for(auto& entry : fixture.tomlTypesData.matchingFormatText)
+	{
+		ASSERT_TRUE(stringResult.find(entry) != std::string::npos) <<
+			"Did not find:\n" << entry << "\nin:\n" << stringResult << std::endl;
+	}
+}
+
+/**
+ * @brief This test reads original MTL platform TOML file.
+*/
+TEST_F(TomlReaderTest, readingTomlMtlFile)
+{
+	const fs::path tomlFileInConfigDirRelative = (fixture.fwsignConfigDir / fixture.exampleTomlFilename);
+	std::string_view fileContent = fileHandler.fileRead(tomlFileInConfigDirRelative);
+	ASSERT_FALSE(fileContent.empty());
+
+	fwsign::TomlReader tomlReader;
+	std::optional<toml::table> result = tomlReader.tomlFileRead(fixture.exampleTomlFilename);
+	ASSERT_TRUE(result.has_value());
+}
+
+}


### PR DESCRIPTION
TomlReader class uses tomlplusplus library to read .toml files and store their content in a "table" class.|
TomlReader has a single readTomlFile() function that accepts a path.

- when the path contains only a filename, local `config` directory is searched for that file
- provided path should point to a file that has .toml extension
- added unit tests validating whether all toml format types are supported and whether
different syntaxes are parsed correctly.
- added unit test that parses original config file from SOF/rimage project for MTL platform

This PR implements following features from #7 :
* FwSign has unit tests that use original [Rimage config files](https://github.com/thesofproject/rimage/tree/main/config) and read their content
* FwSign has a default "config" directory used to load .toml files from it when input arguments contain only filename and extension