### PR TITLE
Added concurrency group to github workflows

### DIFF
--- a/.github/workflows/build-and-ut-fwsign.yml
+++ b/.github/workflows/build-and-ut-fwsign.yml
@@ -8,6 +8,10 @@ on:
     # Allow this workflow to be run from other workflows
   workflow_call:
 
+# Specifies group name that stops previous wokrflows if the name matches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+
 jobs:
   build_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,6 +8,10 @@ on:
   # Allows to run this workflow from Actions tab
   workflow_dispatch:
 
+# Specifies group name that stops previous wokrflows if the name matches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+
 env:
   build_dir: ${{github.workspace}}\build\x64-debug-windows
 

--- a/.github/workflows/style-conformance.yml
+++ b/.github/workflows/style-conformance.yml
@@ -7,6 +7,10 @@ on:
   # Allows to run this workflow from Actions tab
   workflow_dispatch:
 
+# Specifies group name that stops previous wokrflows if the name matches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+
 jobs:
   style_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Concurrency group allows to stop running workflows from running when group name matches. Group name is constructed in the way to be exactly the same for pull requests and commits with the same SHA when merging.

Signed-off-by: Andrey Borisovich <business@borisovich.com>